### PR TITLE
Update pricing and promotional message

### DIFF
--- a/index.html
+++ b/index.html
@@ -921,14 +921,14 @@ fbq('track', 'PageView');
             <div class="elementor-element elementor-element-2508f6c6 elementor-widget elementor-widget-heading" data-element_type="widget" data-id="2508f6c6" data-widget_type="heading.default">
               <div class="elementor-widget-container">
                 <h2 class="elementor-heading-title elementor-size-default">
-                  De <b><del>R$97,90</del></b> por
+                  De <b><del>US$19,00</del></b> por
                 </h2>
               </div>
             </div>
             <div class="elementor-element elementor-element-1162c49e elementor-widget elementor-widget-heading" data-element_type="widget" data-id="1162c49e" data-widget_type="heading.default">
               <div class="elementor-widget-container">
                 <h2 class="elementor-heading-title elementor-size-default">
-                  R$29,90
+                  US$6,00
                 </h2>
               </div>
             </div>
@@ -947,7 +947,7 @@ fbq('track', 'PageView');
             <div class="elementor-element elementor-element-1d952114 elementor-widget elementor-widget-heading" data-element_type="widget" data-id="1d952114" data-widget_type="heading.default">
               <div class="elementor-widget-container">
                 <h2 class="elementor-heading-title elementor-size-default">
-                  Último día con <span style="color:#DD1111;font-weight:700">DESCUENTO</span> do <b>Pequeños Artistas</b>.
+                  Últimas horas para aprovechar el <span style="color:#DD1111;font-weight:700">DESCUENTO</span> de <b>Pequeños Artistas</b>.
                 </h2>
               </div>
             </div>


### PR DESCRIPTION
## Summary
- adjust the original and discounted prices to US$19 and US$6, respectively
- refresh the promotional banner text to emphasize urgency and correct grammar

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e19d4c599c832593e162bfefed954d