### PR TITLE
Update CTA buttons to new WhatsApp link

### DIFF
--- a/index.html
+++ b/index.html
@@ -468,7 +468,7 @@ fbq('track', 'PageView');
             <div class="elementor-element elementor-element-7fa1c069 elementor-mobile-align-center elementor-align-center elementor-widget elementor-widget-button" data-element_type="widget" data-id="7fa1c069" data-widget_type="button.default">
               <div class="elementor-widget-container">
                 <div class="elementor-button-wrapper">
-                  <a class="elementor-button elementor-button-link elementor-size-sm" href="https://pay.hotmart.com/F100220421H?checkoutMode=10"><span class="elementor-button-content-wrapper"><span class="elementor-button-text">¡ACCEDER AHORA!</span></span></a>
+                  <a class="elementor-button elementor-button-link elementor-size-sm" href="https://chat.whatsapp.com/F0dPJdUoWHaDgyN36yQVAs"><span class="elementor-button-content-wrapper"><span class="elementor-button-text">¡ACCEDER AHORA!</span></span></a>
                 </div>
               </div>
             </div>
@@ -935,7 +935,7 @@ fbq('track', 'PageView');
             <div class="elementor-element elementor-element-3d6063d7 elementor-mobile-align-center elementor-align-center elementor-widget elementor-widget-button" data-element_type="widget" data-id="3d6063d7" data-widget_type="button.default">
               <div class="elementor-widget-container">
                 <div class="elementor-button-wrapper">
-                  <a class="elementor-button elementor-button-link elementor-size-sm" href="https://pay.hotmart.com/F100220421H?checkoutMode=10"><span class="elementor-button-content-wrapper"><span class="elementor-button-text">¡COMPRAR AHORA!</span></span></a>
+                  <a class="elementor-button elementor-button-link elementor-size-sm" href="https://chat.whatsapp.com/F0dPJdUoWHaDgyN36yQVAs"><span class="elementor-button-content-wrapper"><span class="elementor-button-text">¡COMPRAR AHORA!</span></span></a>
                 </div>
               </div>
             </div>
@@ -976,7 +976,7 @@ fbq('track', 'PageView');
             </div>
             <div class="elementor-element elementor-element-4ad082ac elementor-widget elementor-widget-image" data-element_type="widget" data-id="4ad082ac" data-widget_type="image.default">
               <div class="elementor-widget-container">
-                <a href="https://api.whatsapp.com/send?1=pt_BR&amp;phone=558999756373"><img alt="" class="attachment-large size-large wp-image-2537" decoding="async" height="256" loading="lazy" sizes="(max-width: 738px) 100vw, 738px" src="https://focoeducativo.com.br/wp-content/uploads/2024/10/botao-whatsapp-do-prime-gourmet-1-2.png" srcset="https://focoeducativo.com.br/wp-content/uploads/2024/10/botao-whatsapp-do-prime-gourmet-1-2.png 738w, https://focoeducativo.com.br/wp-content/uploads/2024/10/botao-whatsapp-do-prime-gourmet-1-2-300x104.png 300w" width="738"/></a>
+                <a href="https://chat.whatsapp.com/F0dPJdUoWHaDgyN36yQVAs"><img alt="" class="attachment-large size-large wp-image-2537" decoding="async" height="256" loading="lazy" sizes="(max-width: 738px) 100vw, 738px" src="https://focoeducativo.com.br/wp-content/uploads/2024/10/botao-whatsapp-do-prime-gourmet-1-2.png" srcset="https://focoeducativo.com.br/wp-content/uploads/2024/10/botao-whatsapp-do-prime-gourmet-1-2.png 738w, https://focoeducativo.com.br/wp-content/uploads/2024/10/botao-whatsapp-do-prime-gourmet-1-2-300x104.png 300w" width="738"/></a>
               </div>
             </div>
           </div>
@@ -1009,7 +1009,7 @@ fbq('track', 'PageView');
             <div class="elementor-element elementor-element-2be93a73 elementor-mobile-align-center elementor-align-center elementor-widget elementor-widget-button" data-element_type="widget" data-id="2be93a73" data-widget_type="button.default">
               <div class="elementor-widget-container">
                 <div class="elementor-button-wrapper">
-                  <a class="elementor-button elementor-button-link elementor-size-sm" href="https://pay.hotmart.com/F100220421H?checkoutMode=10"><span class="elementor-button-content-wrapper"><span class="elementor-button-text">¡LO QUIERO AHORA!</span></span></a>
+                  <a class="elementor-button elementor-button-link elementor-size-sm" href="https://chat.whatsapp.com/F0dPJdUoWHaDgyN36yQVAs"><span class="elementor-button-content-wrapper"><span class="elementor-button-text">¡LO QUIERO AHORA!</span></span></a>
                 </div>
               </div>
             </div>


### PR DESCRIPTION
## Summary
- replace all CTA button destinations with the provided WhatsApp group link
- update the WhatsApp support image button to open the same group chat URL

## Testing
- no automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e19f77daa08325abf4249cb004db54