### PR TITLE
Update pricing values on landing page

### DIFF
--- a/index.html
+++ b/index.html
@@ -921,14 +921,14 @@ fbq('track', 'PageView');
             <div class="elementor-element elementor-element-2508f6c6 elementor-widget elementor-widget-heading" data-element_type="widget" data-id="2508f6c6" data-widget_type="heading.default">
               <div class="elementor-widget-container">
                 <h2 class="elementor-heading-title elementor-size-default">
-                  De <b><del>US$19,00</del></b> por
+                  De <b><del>US$100,00</del></b> por
                 </h2>
               </div>
             </div>
             <div class="elementor-element elementor-element-1162c49e elementor-widget elementor-widget-heading" data-element_type="widget" data-id="1162c49e" data-widget_type="heading.default">
               <div class="elementor-widget-container">
                 <h2 class="elementor-heading-title elementor-size-default">
-                  US$6,00
+                  US$15,00
                 </h2>
               </div>
             </div>


### PR DESCRIPTION
## Summary
- update the crossed-out previous price to US$100,00
- change the promotional price display to US$15,00

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e3cb327724832598ed73e5edef5829